### PR TITLE
Change Searching Order from GetPromiseLibrary.lua to make more sense

### DIFF
--- a/src/GetPromiseLibrary.lua
+++ b/src/GetPromiseLibrary.lua
@@ -4,7 +4,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerScriptService = game:GetService("ServerScriptService")
 local ServerStorage = game:GetService("ServerStorage")
 
-local LOCATIONS_TO_SEARCH = {ReplicatedFirst, ReplicatedStorage, ServerScriptService, ServerStorage, script.Parent.Parent}
+local LOCATIONS_TO_SEARCH = {script.Parent.Parent, ReplicatedStorage, ReplicatedFirst, ServerScriptService, ServerStorage}
 
 local function FindFirstDescendantWithNameAndClassName(Parent: Instance, Name: string, ClassName: string)
 	for _, Descendant in ipairs(Parent:GetDescendants()) do


### PR DESCRIPTION
Made the searching order of GetPromiseLibrary.lua to go over places where it would more logical for a Promise library to be on first.
Before the place where Janitor was stored itself was like *the last* to be looked on, and it's the place where you would keep utils and such.

I know this only gets searched when the module is first required, when the server launches and wouldn't really matter, but I think it isn't that hard to change this so that when you do release a new version you use the new order;