### PR TITLE
Fix moonwave.toml configuration

### DIFF
--- a/moonwave.toml
+++ b/moonwave.toml
@@ -1,12 +1,9 @@
 classOrder = ["Janitor", "RbxScriptConnection"]
 changelog = false
+gitSourceBranch = "main"
 
 [docusaurus]
-projectName = "projectName"
 tagline = "Garbage collector object implementation for Roblox"
-url = "https://howmanysmall.github.io"
-
-[navbar]
 
 [[navbar.items]]
 href = "https://discord.gg/mhtGUS8"


### PR DESCRIPTION
- Removes `projectName` (which was set incorrectly)
- Removes `url` (which is not needed)
- Sets `gitSourceUrl`  correctly so that the edit buttons on the website actually work