### PR TITLE
Changed "pairs" loop to a "while get" loop

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -270,7 +270,18 @@ end
 function Janitor:Cleanup()
 	if not self.CurrentlyCleaning then
 		self.CurrentlyCleaning = nil
-		for Object, MethodName in pairs(self) do
+	
+		local function get(): (any, StringOrTrue)
+			for Object, MethodName in pairs(self) do
+				if Object ~= IndicesReference then
+					return Object, MethodName
+				end
+			end
+		end
+
+		local Object, MethodName = get()
+
+		while Object and MethodName do -- changed to a while loop so that if you add to the janitor inside of a callback it doesn't get untracked (instead it will loop continuously which is a lot better than a hard to pindown edgecase)
 			if Object == IndicesReference then
 				continue
 			end
@@ -285,6 +296,7 @@ function Janitor:Cleanup()
 			end
 
 			self[Object] = nil
+			Object, MethodName = get()
 		end
 
 		local This = self[IndicesReference]

--- a/src/init.lua
+++ b/src/init.lua
@@ -282,10 +282,6 @@ function Janitor:Cleanup()
 		local Object, MethodName = get()
 
 		while Object and MethodName do -- changed to a while loop so that if you add to the janitor inside of a callback it doesn't get untracked (instead it will loop continuously which is a lot better than a hard to pindown edgecase)
-			if Object == IndicesReference then
-				continue
-			end
-
 			if MethodName == true then
 				Object()
 			else


### PR DESCRIPTION
If you add to the janitor in one of the cleanup functions you will create untracked connections/functions/etc

An example where the old janitor cleanup method would falter: 
```lua
local obliterator = JANITOR.new()

obliterator:Add(function()
  print("cleanup 1") -- reached at first cleanup
  obliterator:Add(function()
      print("cleanup 2") -- reached at second cleanup
  end)
end)

obliterator:Cleanup()
obliterator:Cleanup()
```

PS: The maid module has this same "while get" loop (could be the reason why janitor is faster 🤷 )