### PR TITLE
Added BindToRenderStep function

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -5,6 +5,8 @@
 -- LinkToInstance fixed by Elttob.
 -- Cleanup edge cases fixed by codesenseAye.
 
+local RunService = game:GetService("RunService")
+
 local GetPromiseLibrary = require(script.GetPromiseLibrary)
 local Symbol = require(script.Symbol)
 local FoundPromiseLibrary, Promise = GetPromiseLibrary()
@@ -173,6 +175,30 @@ function Janitor:AddPromise(PromiseObject)
 	else
 		return PromiseObject
 	end
+end
+
+--[=[
+	Registers a `RunService:BindToRenderStep` function to the Janitor. Will unbind the RenderStep on cleanup. Returns the binded name.
+	```lua
+	local Obliterator = Janitor.new()
+	Obliterator:BindToRenderStep("Example", Enum.RenderPriority.Camera.Value + 1, function(dt)
+		-- Do something during the render step
+	end)
+	```
+
+	@param BindName string -- The name of the RunService method to register.
+	@param Priority number -- Priority of the RunService binding.
+	@param Function (dt: number) -> nil -- Custom function being bound.
+	@return MethodName: string
+]=]
+function Janitor:BindToRenderStep(BindName: string, Priority: number, Function: (dt: number) -> nil, Index: any?): string
+	RunService:BindToRenderStep(BindName, Priority, Function)
+
+	self:Add(function()
+		RunService:UnbindFromRenderStep(BindName)
+	end, true, Index)
+
+	return BindName
 end
 
 --[=[

--- a/test/Janitor.spec.lua
+++ b/test/Janitor.spec.lua
@@ -1,3 +1,5 @@
+local RunService = game:GetService("RunService")
+
 -- TestEZ types (for autocomplete)
 type Dictionary<Value> = {[string]: Value}
 type DescribeFunction = (Dictionary<any>?) -> nil
@@ -240,6 +242,90 @@ return function()
 			expect(function()
 				NewJanitor:AddPromise(BasicClass.new())
 			end).to.throw()
+
+			NewJanitor:Destroy()
+		end)
+	end)
+
+	describe("BindToRenderStep", function()
+		it("should return the name of the bind", function()
+			local BindName = "TestBind"
+			local NewJanitor = Janitor.new()
+			local ReturnedName = NewJanitor:BindToRenderStep(BindName, Enum.RenderPriority.Camera.Value, function(_dt) end)
+			print(ReturnedName)
+			expect(ReturnedName).to.equal(BindName)
+			NewJanitor:Destroy()
+		end)
+
+		it("should correctly bind a function to the render step", function()
+			local BindName = "TestBind"
+			local NewJanitor = Janitor.new()
+			local Number = 0
+			NewJanitor:BindToRenderStep(BindName, Enum.RenderPriority.Camera.Value, function(_dt)
+				Number += 1
+			end)
+			RunService.RenderStepped:Wait()
+			expect(Number).to.equal(1)
+			NewJanitor:Destroy()
+		end)
+
+		it("should be able to unbind the function from the render step", function()
+			local BindName = "TestBind"
+			local NewJanitor = Janitor.new()
+			local Number = 0
+			NewJanitor:BindToRenderStep(BindName, Enum.RenderPriority.Camera.Value, function(_dt)
+				Number += 1
+			end)
+			RunService.RenderStepped:Wait()
+			expect(Number).to.equal(1)
+			NewJanitor:Destroy()
+			RunService.RenderStepped:Wait()
+			expect(Number).to.equal(1)
+		end)
+
+		it("should be able to bind more than one function to the render step", function()
+			local BindName = "TestBind"
+			local AnotherBindName = "AnotherTestBind"
+			local NewJanitor = Janitor.new()
+			local Number = 0
+			local AnotherNumber = 0
+
+			NewJanitor:BindToRenderStep(BindName, Enum.RenderPriority.Camera.Value, function(_dt)
+				Number += 1
+			end, "Test")
+
+			NewJanitor:BindToRenderStep(AnotherBindName, Enum.RenderPriority.Camera.Value, function(_dt)
+				AnotherNumber += 10
+			end, "AnotherTest")
+
+			RunService.RenderStepped:Wait()
+
+			expect(Number).to.equal(1)
+			expect(AnotherNumber).to.equal(10)
+
+			NewJanitor:Destroy()
+		end)
+
+		it("should be able to unbind a specific function from the render step", function()
+			local BindName = "TestBind"
+			local AnotherBindName = "AnotherTestBind"
+			local NewJanitor = Janitor.new()
+			local Number = 0
+			local AnotherNumber = 0
+
+			NewJanitor:BindToRenderStep(BindName, Enum.RenderPriority.Camera.Value, function(_dt)
+				Number += 1
+			end, "Test")
+
+			NewJanitor:BindToRenderStep(AnotherBindName, Enum.RenderPriority.Camera.Value, function(_dt)
+				AnotherNumber += 1
+			end, "AnotherTest")
+
+			NewJanitor:Remove("Test")
+			RunService.RenderStepped:Wait()
+
+			expect(Number).to.equal(0)
+			expect(AnotherNumber).to.equal(1)
 
 			NewJanitor:Destroy()
 		end)


### PR DESCRIPTION
Added a function that allows for a render step function to be easily added to a janitor.

Currently, if you wish to create add a render step bind to the janitor, you must just add the Unbind function within a custom function. This simplifies that process and does it all in one go.