### PR TITLE
Call functions added for cleanup in a new coroutine

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -443,7 +443,7 @@ function Janitor:Cleanup()
 			else
 				local ObjectMethod = Object[MethodName]
 				if ObjectMethod then
-					ObjectMethod(Object)
+					task.spawn(ObjectMethod, Object)
 				end
 			end
 
@@ -605,7 +605,7 @@ function Janitor:LegacyLinkToInstance(Object: Instance, AllowMultiple: boolean?)
 	ManualDisconnect.Connection = Connection
 
 	if IsNilParented then
-		ChangedFunction(nil, Object.Parent)
+		task.spawn(ChangedFunction, nil, Object.Parent)
 	end
 
 	Object = nil :: any


### PR DESCRIPTION
Currently, my janitor functions yield like so:

```lua
janitor:Add(function()
    -- some yielding operation
end)
```

This causes other cleanup methods to be delayed of course which isn't expected behavior, and I and (mostly no-one) wants to go through the headache of handling these yielding operations in a new thread just because of how Janitor works.