### PR TITLE
Error when calling task.cancel on a running thread

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added 
+
+### Fixed
+
+- Fixed Janitor error when attempting call task.cancel on a running thread
+
 ## 1.4.1 - 2022-03-17
 
 ### Added

--- a/src/init.lua
+++ b/src/init.lua
@@ -270,7 +270,7 @@ function Janitor:Remove(Index: any)
 					if type(Object) == "function" then
 						Object()
 					else
-						task.cancel(Object)
+						pcall(task.cancel, Object)
 					end
 				else
 					local ObjectMethod = Object[MethodName]
@@ -348,7 +348,7 @@ function Janitor:RemoveList(...: any)
 							if type(Object) == "function" then
 								Object()
 							else
-								task.cancel(Object)
+								pcall(task.cancel, Object)
 							end
 						else
 							local ObjectMethod = Object[MethodName]
@@ -438,7 +438,7 @@ function Janitor:Cleanup()
 				if type(Object) == "function" then
 					Object()
 				else
-					task.cancel(Object)
+					pcall(task.cancel, Object)
 				end
 			else
 				local ObjectMethod = Object[MethodName]


### PR DESCRIPTION
- Fixed Janitor error when attempting call task.cancel on a running thread

```lua
local janitor = Janitor.new()
janitor:Add(task.delay(1, function()
    janitor:Destroy()
end))
```