### PR TITLE
Avoid double-destroying instances

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -31,7 +31,7 @@ local Janitor = {}
 Janitor.ClassName = "Janitor"
 Janitor.CurrentlyCleaning = true
 Janitor[IndicesReference] = nil
-Janitor.SuppressInstanceReDestroy = false;
+Janitor.SuppressInstanceReDestroy = false
 Janitor.__index = Janitor
 
 --[=[

--- a/src/init.lua
+++ b/src/init.lua
@@ -27,12 +27,11 @@ type RbxScriptConnection = RbxScriptConnection.RbxScriptConnection
 
 	@class Janitor
 ]=]
-local Janitor = {
-	SuppressInstanceReDestroy = false;
-}
+local Janitor = {}
 Janitor.ClassName = "Janitor"
 Janitor.CurrentlyCleaning = true
 Janitor[IndicesReference] = nil
+Janitor.SuppressInstanceReDestroy = false;
 Janitor.__index = Janitor
 
 --[=[

--- a/src/init.lua
+++ b/src/init.lua
@@ -275,7 +275,11 @@ function Janitor:Remove(Index: any)
 				else
 					local ObjectMethod = Object[MethodName]
 					if ObjectMethod then
-						ObjectMethod(Object)
+						if typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+							pcall(ObjectMethod, Object)
+						else
+							ObjectMethod(Object)
+						end
 					end
 				end
 
@@ -398,7 +402,11 @@ function Janitor:RemoveList(...: any)
 						else
 							local ObjectMethod = Object[MethodName]
 							if ObjectMethod then
-								ObjectMethod(Object)
+								if typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+									pcall(ObjectMethod, Object)
+								else
+									ObjectMethod(Object)
+								end
 							end
 						end
 
@@ -582,7 +590,11 @@ function Janitor:Cleanup()
 			else
 				local ObjectMethod = Object[MethodName]
 				if ObjectMethod then
-					ObjectMethod(Object)
+					if typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+						pcall(ObjectMethod, Object)
+					else
+						ObjectMethod(Object)
+					end
 				end
 			end
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -27,7 +27,9 @@ type RbxScriptConnection = RbxScriptConnection.RbxScriptConnection
 
 	@class Janitor
 ]=]
-local Janitor = {}
+local Janitor = {
+	SuppressInstanceReDestroy = false;
+}
 Janitor.ClassName = "Janitor"
 Janitor.CurrentlyCleaning = true
 Janitor[IndicesReference] = nil
@@ -275,7 +277,7 @@ function Janitor:Remove(Index: any)
 				else
 					local ObjectMethod = Object[MethodName]
 					if ObjectMethod then
-						if typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+						if self.SuppressInstanceReDestroy and typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
 							pcall(ObjectMethod, Object)
 						else
 							ObjectMethod(Object)
@@ -402,7 +404,7 @@ function Janitor:RemoveList(...: any)
 						else
 							local ObjectMethod = Object[MethodName]
 							if ObjectMethod then
-								if typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+								if self.SuppressInstanceReDestroy and typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
 									pcall(ObjectMethod, Object)
 								else
 									ObjectMethod(Object)
@@ -590,7 +592,7 @@ function Janitor:Cleanup()
 			else
 				local ObjectMethod = Object[MethodName]
 				if ObjectMethod then
-					if typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+					if self.SuppressInstanceReDestroy and typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
 						pcall(ObjectMethod, Object)
 					else
 						ObjectMethod(Object)

--- a/src/init.lua
+++ b/src/init.lua
@@ -288,7 +288,7 @@ function Janitor:Remove(Index: any)
 				else
 					local ObjectMethod = Object[MethodName]
 					if ObjectMethod then
-						if self.SuppressInstanceReDestroy and typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+						if self.SuppressInstanceReDestroy and MethodName == "Destroy" and typeof(Object) == "Instance" then
 							pcall(ObjectMethod, Object)
 						else
 							ObjectMethod(Object)
@@ -426,7 +426,7 @@ function Janitor:RemoveList(...: any)
 						else
 							local ObjectMethod = Object[MethodName]
 							if ObjectMethod then
-								if self.SuppressInstanceReDestroy and typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+								if self.SuppressInstanceReDestroy and MethodName == "Destroy" and typeof(Object) == "Instance" then
 									pcall(ObjectMethod, Object)
 								else
 									ObjectMethod(Object)

--- a/src/init.lua
+++ b/src/init.lua
@@ -624,7 +624,7 @@ function Janitor:Cleanup()
 			else
 				local ObjectMethod = Object[MethodName]
 				if ObjectMethod then
-					if self.SuppressInstanceReDestroy and typeof(Object) == "Instance" then -- avoids error if the object is already destroyed
+					if self.SuppressInstanceReDestroy and MethodName == "Destroy" and typeof(Object) == "Instance" then
 						pcall(ObjectMethod, Object)
 					else
 						ObjectMethod(Object)


### PR DESCRIPTION
May be another solution here, but my janitors run into errors when used in the following configuration:

1. GuiModule creates a gui, adds to `guiJanitor`
2. GuiModule creates a GuiComponent class, which uses LinkToInstance to destroy the component when the component's gui is destroyed.
3. Gui class calls `guiJanitor:Cleanup()`, destroying the gui and the descendant component instance. This triggers the component class's LinkToInstance cleanup after the descendant component instance was already destroyed, resulting in an error.

As it's impossible to check if an instance has been destroyed already as opposed to just parented to nil, this change adds a pcall for only instance:Destroy() calls during cleanup.

Simple case:
```lua
local j = Janitor.new()
j:Add(workspace.p)
j:LinkToInstance(workspace.p)
workspace.p:Destroy() -- Ancestor destroyed maybe
--> `The Parent property of Workspace.p is locked`
```