### PR TITLE
Removed dev dependencies

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -11,7 +11,3 @@ include = ["src", "src/**", "wally.toml", "wally.lock", "default.project.json", 
 
 [dependencies]
 Promise = "evaera/promise@4.0.0"
-
-[dev-dependencies]
-Jest = "jsdotlua/jest@3.6.1-rc.2"
-JestGlobals = "jsdotlua/jest-globals@3.6.1-rc.2"


### PR DESCRIPTION
can't do Wally install on the package because of a Wally error saying 'A dev dependency cannot be depended upon by a non-dev dependency'